### PR TITLE
Add a playground URL to the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ const mapSizesToProps = ({ width }) => ({
 
 export Sizes(mapSizesToProps)(MyComponent);
 ```
+You can play with this example [here](https://codesandbox.io/s/Rg0DDOWnE).
 
 #### As decorator.
 ```jsx


### PR DESCRIPTION
This adds a url to CodeSandbox so others can play with the library and see an example.