### PR TITLE
Dispatch sizes again when the props are updated

### DIFF
--- a/src/withSizes.js
+++ b/src/withSizes.js
@@ -59,6 +59,10 @@ const withSizes = (...mappedSizesToProps) => WrappedComponent => {
 
     /* Lifecycles */
 
+    componentWillReceiveProps() {
+      this.dispatchSizes()
+    }
+
     componentDidMount() {
       window.addEventListener('resize', this.throttledDispatchSizes)
       this.dispatchSizes()


### PR DESCRIPTION
The ["Mess with props" example](https://github.com/renatorib/react-sizes#mess-with-props) in the README.md file doesn't work if the component property (`mobileBreakpoint` in that example) is dynamic.

Let's imagine you have a slider to adjust the value of that props. If you interact with the slider once the component is mounted (`componentDidMount` has been called), the `mapSizesToProps` is not called until the window is resized.

This PR simply adds a `componentDidUpdate` method which triggers `this.dispatchSizes()`.

