### PR TITLE
prevent memory leak

### DIFF
--- a/src/withSizes.js
+++ b/src/withSizes.js
@@ -69,6 +69,7 @@ const withSizes = (...mappedSizesToProps) => WrappedComponent => {
     }
 
     componentWillUnmount() {
+      this.throttledDispatchSizes.cancel()
       window.removeEventListener('resize', this.throttledDispatchSizes)
     }
 


### PR DESCRIPTION
added throttle cancel method in componentWillUnmount()

this PR fixed [issue](https://github.com/renatorib/react-sizes/issues/38)