### PR TITLE
Fixed `throttle` config param passing to wrapped components

### DIFF
--- a/src/SizesContext.js
+++ b/src/SizesContext.js
@@ -1,6 +1,8 @@
 import React from 'react'
 
 const SizesContext = React.createContext({
+  // Keep these fields in sync with the excluded fields in the `render()`
+  // function of `withSizes.js`
   fallbackWidth: null,
   fallbackHeight: null,
   forceFallback: false,

--- a/src/withSizes.js
+++ b/src/withSizes.js
@@ -75,9 +75,12 @@ const withSizes = (...mappedSizesToProps) => WrappedComponent => {
 
     render() {
       const {
+        // Ensure all the `SizesContext.js` arguments are excluded.
+        // Keep this in sync with `SizesContextjs` fields
         fallbackHeight,
         fallbackWidth,
         forceFallback,
+        throttle,
         ...otherProps
       } = this.props
 


### PR DESCRIPTION
The `throttle` configuration parameter is being passed down to wrapped components, triggering an error. This one-line fix should fix it. I also added a comment to prevent this from happening in the future.