### PR TITLE
feat: add useDocumentElement option

### DIFF
--- a/.storybook/stories/index.js
+++ b/.storybook/stories/index.js
@@ -5,7 +5,7 @@ import MobileBreakpoint from '../components/MobileBreakpoint'
 import withSizes from '../../src/withSizes'
 import SizesProvider from '../../src/SizesProvider'
 
-const mapSizesToProps = sizes => ({
+const mapSizesToProps = (sizes) => ({
   backgroundColor: sizes.width > 800 ? 'green' : 'blue',
   isMobile: withSizes.isMobile(sizes),
   isTablet: withSizes.isTablet(sizes),
@@ -24,6 +24,73 @@ const ExampleSizedComponent = withSizes(mapSizesToProps)(
     </div>
   )
 )
+
+class DocumentElementExample extends React.Component {
+  state = {
+    windowWidth: window.innerWidth,
+    documentWidth: document.documentElement.clientWidth,
+  }
+
+  constructor(...args) {
+    super(...args)
+    this.resetState = this.resetState.bind(this)
+  }
+
+  resetState() {
+    this.setState({
+      windowWidth: window.innerWidth,
+      documentWidth: document.documentElement.clientWidth,
+    })
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this.resetState)
+    this.resetState()
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.resetState)
+  }
+
+  render() {
+    return (
+      <>
+        <style>
+          {`html {
+            overflow-y: scroll;
+          }`}
+        </style>
+        <SizesProvider config={{ useDocumentElement: true }}>
+          <Result>
+            <ExampleSizedComponent />
+            <table>
+              <thead>
+                <tr>
+                  <th>
+                    <pre>window.innerWidth</pre>
+                  </th>
+                  <th>
+                    <pre>document.documentElement.clientWidth</pre>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <pre>{this.state.windowWidth}</pre>
+                  </td>
+                  <td>
+                    <pre>{this.state.documentWidth}</pre>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </Result>
+        </SizesProvider>
+      </>
+    )
+  }
+}
 
 class ForceFallbackExample extends React.Component {
   state = {
@@ -82,6 +149,7 @@ const ExampleSizedComponent = withSizes(mapSizesToProps)(
       </Code>
     </div>
   ))
+  .add('useDocumentElement', () => <DocumentElementExample />)
   .add('mobileBreakpoint', () => (
     <div>
       <MobileBreakpoint breakpoint={300} />

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ const MyComponent = enhancer(({ isMobile, counter, setCounter }) => (
   <div>
     <div>
       Count: {counter}{' '}
-      <button onClick={() => setCounter(n => n + 1)}>Increment</button>
+      <button onClick={() => setCounter((n) => n + 1)}>Increment</button>
     </div>
     <div>{isMobile ? 'Is Mobile' : 'Is Not Mobile'}</div>
   </div>
@@ -154,14 +154,14 @@ withSizes.isMobile = ({ width }) => width < 480
 withSizes.isTablet = ({ width }) => width >= 480 && width < 1024
 withSizes.isDesktop = ({ width }) => width >= 1024
 
-withSizes.isGtMobile = sizes => !withSizes.isMobile(sizes)
-withSizes.isGtTablet = sizes => withSizes.isDesktop(sizes)
+withSizes.isGtMobile = (sizes) => !withSizes.isMobile(sizes)
+withSizes.isGtTablet = (sizes) => withSizes.isDesktop(sizes)
 
-withSizes.isStTablet = sizes => withSizes.isMobile(sizes)
-withSizes.isStDesktop = sizes => !withSizes.isStDesktop(sizes)
+withSizes.isStTablet = (sizes) => withSizes.isMobile(sizes)
+withSizes.isStDesktop = (sizes) => !withSizes.isStDesktop(sizes)
 
-withSizes.isTabletAndGreater = sizes => !withSizes.isMobile(sizes)
-withSizes.isTabletAndSmaller = sizes => !withSizes.isStDesktop(sizes)
+withSizes.isTabletAndGreater = (sizes) => !withSizes.isMobile(sizes)
+withSizes.isTabletAndSmaller = (sizes) => !withSizes.isStDesktop(sizes)
 ```
 
 If it don't fit to your needs, you can create your own selectors.
@@ -174,13 +174,23 @@ export const backgroundColor = ({ width }) => (width < 480 ? 'red' : 'green')
 // your component
 import { isntDesktop, backgroundColor } from 'utils/sizes/selectors'
 
-const mapSizesToProps = sizes => ({
+const mapSizesToProps = (sizes) => ({
   canDisplayMobileFeature: isntDesktop(sizes),
   backgroundColor: backgroundColor(sizes),
 })
 ```
 
 > `sizes` argument is an object with `width` and `height` properties and represents DOM window width and height.
+
+## Window Width Resource
+
+By default react-sizes will use `window.innerWidth` to determine the width of the current window. This will also take in to account a body scroll bar. If you'd rather ignore the body's scrollbar and base the size on the document's client width, pass the `useDocumentElement` option:
+
+```jsx
+<SizeProvider config={{ useDocumentElement: true }}>
+  <App />
+</SizeProvider>
+```
 
 ## Guide
 
@@ -189,7 +199,7 @@ const mapSizesToProps = sizes => ({
 `sizes` argument is an object with `width` and `height` of DOM window.
 
 ```js
-const mapSizesToProps = sizes => {
+const mapSizesToProps = (sizes) => {
   console.log(sizes) // { width: 1200, height: 720 } (example)
 }
 ```
@@ -197,7 +207,7 @@ const mapSizesToProps = sizes => {
 In pratice, it is a callback that return props that will injected into your Component.
 
 ```js
-const mapSizesToProps = function(sizes) {
+const mapSizesToProps = function (sizes) {
   const props = {
     backgroundColor: sizes.width < 700 ? 'red' : 'green',
   }
@@ -238,7 +248,7 @@ import Express from 'express'
 import { SizesProvider } from 'react-sizes'
 // All other imports
 
-const getSizesFallback = userAgent => {
+const getSizesFallback = (userAgent) => {
   const md = new MobileDetect(userAgent)
 
   if (!!md.mobile()) {

--- a/src/SizesContext.js
+++ b/src/SizesContext.js
@@ -1,6 +1,7 @@
 import React from 'react'
 
 const SizesContext = React.createContext({
+  useDocumentElement: false,
   fallbackWidth: null,
   fallbackHeight: null,
   forceFallback: false,

--- a/src/utils/getWindowSizes.js
+++ b/src/utils/getWindowSizes.js
@@ -1,9 +1,24 @@
-const getWindowSizes = ({ fallbackWidth = null, fallbackHeight = null, forceFallback = false }) => {
+const getWindowSizes = ({
+  useDocumentElement = false,
+  fallbackWidth = null,
+  fallbackHeight = null,
+  forceFallback = false,
+}) => {
   const canUseDOM = typeof window !== 'undefined'
 
   return {
-    width: canUseDOM && !forceFallback ? window.innerWidth : fallbackWidth,
-    height: canUseDOM && !forceFallback ? window.innerHeight : fallbackHeight,
+    width:
+      canUseDOM && !forceFallback
+        ? useDocumentElement
+          ? document.documentElement.clientWidth
+          : window.innerWidth
+        : fallbackWidth,
+    height:
+      canUseDOM && !forceFallback
+        ? useDocumentElement
+          ? document.documentElement.clientHeight
+          : window.innerHeight
+        : fallbackHeight,
     canUseDOM,
   }
 }

--- a/src/withSizes.js
+++ b/src/withSizes.js
@@ -9,15 +9,25 @@ import getWindowSizes from './utils/getWindowSizes'
 import SizesContext from './SizesContext'
 import * as presets from './presets'
 
-const getWindowSizesWithFallback = props => {
-  const { fallbackHeight, fallbackWidth, forceFallback } = props
-  return getWindowSizes({ fallbackHeight, fallbackWidth, forceFallback })
+const getWindowSizesWithFallback = (props) => {
+  const {
+    useDocumentElement,
+    fallbackHeight,
+    fallbackWidth,
+    forceFallback,
+  } = props
+  return getWindowSizes({
+    useDocumentElement,
+    fallbackHeight,
+    fallbackWidth,
+    forceFallback,
+  })
 }
 
-const withSizes = (...mappedSizesToProps) => WrappedComponent => {
+const withSizes = (...mappedSizesToProps) => (WrappedComponent) => {
   const parseMappedSizesToProps = (dimensions, props) =>
     mappedSizesToProps
-      .map(check => check(dimensions, props))
+      .map((check) => check(dimensions, props))
       .reduce((acc, props) => ({ ...acc, ...props }), {})
 
   class ComponentWithSizes extends PureComponent {
@@ -85,9 +95,9 @@ const withSizes = (...mappedSizesToProps) => WrappedComponent => {
     }
   }
 
-  const WithSizes = props => (
+  const WithSizes = (props) => (
     <SizesContext.Consumer>
-      {config => <ComponentWithSizes {...config} {...props} />}
+      {(config) => <ComponentWithSizes {...config} {...props} />}
     </SizesContext.Consumer>
   )
 


### PR DESCRIPTION
I am using other libraries which use an alternative way in finding the window size (document width) (`document.documentElement.clientWidth`). Which, unlike `window.innerWidth`, doesn't add the width of the body's scroll bar to it's final value. The difference in pixels will differ from OS, browser & any additional UI enhancements, and trying to use react-sizes with these libraries *can* be troublesome.

Below is an example of how chrome will differ, between these 2 values, in windows 10.

<img width="1791" alt="react-resizes-document" src="https://user-images.githubusercontent.com/1423566/92558852-c74c7a80-f2b2-11ea-95c3-934e1b549dac.png">

It would be nice if either `react-sizes` used document width too, or at least had the ability to do so. This pull request adds a configuration option to use the document width instead.

There are a few changes in this pull request added by prettier, which I did not add myself (just incase you thought I was being unhelpfully pedantic).